### PR TITLE
IASC-561 unselect promote to front page as default

### DIFF
--- a/config/core.base_field_override.node.announcement.promote.yml
+++ b/config/core.base_field_override.node.announcement.promote.yml
@@ -1,0 +1,22 @@
+uuid: ee74f6fb-7eae-48ec-995a-233177e6d1e8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+id: node.announcement.promote
+field_name: promote
+entity_type: node
+bundle: announcement
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.oa_wiki_page.promote.yml
+++ b/config/core.base_field_override.node.oa_wiki_page.promote.yml
@@ -1,0 +1,22 @@
+uuid: 91635491-ac00-4229-803d-60818e128a44
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.oa_wiki_page
+id: node.oa_wiki_page.promote
+field_name: promote
+entity_type: node
+bundle: oa_wiki_page
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean


### PR DESCRIPTION
for announcement and document content types. This prevents nodes appearing in the Featured component on the homepage by default