### PR TITLE
IASC-561 add zip to file formats allowed to upload

### DIFF
--- a/config/field.field.media.file.field_media_file.yml
+++ b/config/field.field.media.file.field_media_file.yml
@@ -24,9 +24,9 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'txt rtf doc docx ppt pptx xls xlsx pdf odf odg odp ods odt fodt fods fodp fodg key numbers pages'
+  file_extensions: 'txt rtf doc docx ppt pptx xls xlsx pdf odf odg odp ods odt fodt fods fodp fodg key numbers pages zip'
   max_filesize: ''
+  description_field: false
   handler: 'default:file'
   handler_settings: {  }
-  description_field: false
 field_type: file


### PR DESCRIPTION
FYI @attiks This is to cater for this page:
https://interagencystandingcommittee.org//node/40193
which is new since the migration. Notice attached zips

The zips contain .brf, .smil, .epub and .html - multiple files per zip

D8 version is here: https://test.interagencystandingcommittee.org/iasc-guidelines-inclusion-persons-disabilities-humanitarian-action-2019