### PR TITLE
IASC-611 remove html formatting from Document teaser

### DIFF
--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--teaser.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--teaser.html.twig
@@ -109,7 +109,14 @@
     {{ title_suffix }}
 
     <div class="cd-article-teaser__description node__content">
-      {{ content|without('field_product_thumbnail','field_thumbnail','field_media_files') }}
+      {{ content|without('field_product_thumbnail','body', 'field_thumbnail','field_media_files') }}
+
+      {% set contentBody %}
+        {{ content.body }}
+      {% endset %}
+
+      {{ contentBody|striptags }}
+
     </div>
   </div>
 


### PR DESCRIPTION
remove html formatting from Document teaser body field in twig template, the prevent issues with tags not closing at summary text cut-off