### PR TITLE
IASC-650 reset GTM ID in favour of ENV vars

### DIFF
--- a/config/google_tag.container.default.yml
+++ b/config/google_tag.container.default.yml
@@ -8,7 +8,7 @@ dependencies:
 id: default
 label: default
 weight: 0
-container_id: GTM-KBPXZSN
+container_id: GTM-xxxx
 data_layer: dataLayer
 include_classes: false
 whitelist_classes: "google\nnonGooglePixels\nnonGoogleScripts\nnonGoogleIframes"
@@ -23,6 +23,12 @@ role_list: {  }
 status_toggle: 'exclude listed'
 status_list: "403\n404"
 conditions:
+  group_type:
+    id: group_type
+    group_types: {  }
+    negate: 0
+    context_mapping:
+      group: '@group.group_route_context:group'
   'entity_bundle:group':
     id: 'entity_bundle:group'
     bundles: {  }
@@ -35,9 +41,3 @@ conditions:
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
-  group_type:
-    id: group_type
-    group_types: {  }
-    negate: 0
-    context_mapping:
-      group: '@group.group_route_context:group'


### PR DESCRIPTION
Reverse commit here https://github.com/UN-OCHA/iasc8/pull/303/files after discovering GTM ID is added in ENV vars