### PR TITLE
[HOTFIX-1] Try to get a backtrace when the "" entity type error happens.

### DIFF
--- a/PATCHES/core_backtrace_entitymanager.patch
+++ b/PATCHES/core_backtrace_entitymanager.patch
@@ -1,0 +1,20 @@
+diff --git a/core/lib/Drupal/Core/Entity/EntityTypeManager.php b/core/lib/Drupal/Core/Entity/EntityTypeManager.php
+index b2d1d29..d19a26e 100644
+--- a/core/lib/Drupal/Core/Entity/EntityTypeManager.php	2020-09-15 14:04:16.000000000 +1000
++++ b/core/lib/Drupal/Core/Entity/EntityTypeManager.php	2020-09-15 14:03:40.000000000 +1000
+@@ -147,6 +147,15 @@
+       return NULL;
+     }
+ 
++    // This is not very nice, but really, I want the backtrace.
++    ob_start();
++    debug_print_backtrace();
++    $backtrace = ob_get_contents();
++    ob_end_clean();
++
++    // And drop the backtrace in the logs.
++    \Drupal::logger('entity')->error($backtrace);
++
+     throw new PluginNotFoundException($entity_type_id, sprintf('The "%s" entity type does not exist.', $entity_type_id));
+   }
+

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -9,6 +9,9 @@
     "drupal/group": {
       "https://www.drupal.org/project/group/issues/2817109 - How to redirect to the owning group after adding a gnode?": "https://www.drupal.org/files/issues/2817109-by-rachel_norfolk-ericras-How-to-redir.patch",
       "https://www.drupal.org/project/group/issues/2873212 - Add a status to the group (Publish/Unpublish)": "https://www.drupal.org/files/issues/2019-11-19/group-status-2873212-17.patch"
+    },
+    "drupal/core": {
+      "Attempt to debug intermittent 'The \"\" entity type does not exist.'": "PATCHES/core_backtrace_entitymanager.patch"
     }
   }
 }


### PR DESCRIPTION
This should in theory drop a backtrace into ELK, so it'll never end up visible to end users.