### PR TITLE
[OPS-7022] Make node_view_permissions write correct grants for nodes …

### DIFF
--- a/PATCHES/node_view_permissions_language_und.patch
+++ b/PATCHES/node_view_permissions_language_und.patch
@@ -1,0 +1,11 @@
+--- node_view_permissions/node_view_permissions.module	2020-10-14 08:18:56.000000000 +1100
++++ node_view_permissions/node_view_permissions.module	2020-10-14 08:17:50.000000000 +1100
+@@ -20,7 +20,7 @@
+   // We don't want to override view published permissions.
+   $languages = $node->getTranslationLanguages();
+   foreach ($languages as $langcode => $language) {
+-    if ($langcode === Language::LANGCODE_NOT_APPLICABLE) {
++    if ($langcode === Language::LANGCODE_NOT_APPLICABLE || $langcode === Language::LANGCODE_NOT_SPECIFIED) {
+       // If node is not translatable, check the publish status of it.
+       if ($node->isPublished()) {
+         $grants[] = [

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -12,6 +12,9 @@
     },
     "drupal/core": {
       "Attempt to debug intermittent 'The \"\" entity type does not exist.'": "PATCHES/core_backtrace_entitymanager.patch"
+    },
+    "drupal/node_view_permissions": {
+      "Handle accessfor Language::LANGCODE_NOT_SPECIFIED": "PATCHES/node_view_permissions_language_und.patch"
     }
   }
 }


### PR DESCRIPTION
…with LANGCODE_NOT_SPECIFIED.

This branch is current deployed to the `dev` environment and appears to resolve the problem.