### PR TITLE
[OPS-7634] update php version in github hook task

### DIFF
--- a/.github/workflows/outdated.yml
+++ b/.github/workflows/outdated.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: develop
       - name: Composer Update
-        uses: docker://unocha/unified-builder:7.3-stable
+        uses: docker://unocha/unified-builder:7.4-develop
         with:
           args: composer update --with-dependencies drupal/* 
       - name: Create Pull Request


### PR DESCRIPTION
Failed task 'Composer Update / build (push) ' https://github.com/UN-OCHA/iasc8/pull/506/checks?check_run_id=3192154470 - may need some more steps, but at least needs the version of php updated.