### PR TITLE
[OPS-7913] adjust patch path for scaffold

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -158,7 +158,7 @@
             },
             "file-mapping": {
               "[web-root]/robots.txt": {
-                "append": "PATCHES/robots.txt.append"
+                "append": "../PATCHES/robots.txt.append"
               }
             }
         }


### PR DESCRIPTION
Follow-on to https://github.com/UN-OCHA/iasc8/pull/543 - https://jenkins.aws.ahconu.org/job/iasc-dev-file-proxy-enable/59/console complains that it can't find a patch for the scaffold - this adjusts its path.