### PR TITLE
Feature/IASC-725 search file error

### DIFF
--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--teaser.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--teaser.html.twig
@@ -85,10 +85,9 @@
 
 {# // Only try to set the file url if there is a file. #}
 {% if content.field_media_files[0]['#media'] %}
-{%   set fileUrl = file_url(content.field_media_files[0]['#media'].field_media_file.entity.uri.value) %}
-{% else %}
-{%   set showPage = node.field_oa_wiki_page_no_redirect.0.value %}
+  {% set fileUrl = file_url(content.field_media_files[0]['#media'].field_media_file.entity.uri.value) %}
 {% endif %}
+{% set showPage = node.field_oa_wiki_page_no_redirect.0.value %}
 
 <article{{ attributes.addClass(classes) }}>
 
@@ -102,7 +101,9 @@
     {{ title_prefix }}
     {% if label and not page %}
       <h3{{ title_attributes.addClass('cd-teaser__title') }}>
-        {% if showPage %}
+        {% if showPage is same as '1' %}
+          <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+        {% elseif showPage is same as '0' and fileURL is null %}
           <a href="{{ url }}" rel="bookmark">{{ label }}</a>
         {% else %}
           <a href="{{ fileUrl }}" title="Download">{{ label }}</a>

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--teaser.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--teaser.html.twig
@@ -83,10 +83,7 @@
 %}
 {{ attach_library('common_design/cd-teaser') }}
 
-{# // Only try to set the file url if there is a file. #}
-{% if content.field_media_files[0]['#media'] %}
-  {% set fileUrl = file_url(content.field_media_files[0]['#media'].field_media_file.entity.uri.value) %}
-{% endif %}
+{% set fileUrl = node.field_media_files.0.entity.uri.value ? file_url(node.field_media_files.0.entity.uri.value) :  url  %}
 {% set showPage = node.field_oa_wiki_page_no_redirect.0.value %}
 
 <article{{ attributes.addClass(classes) }}>
@@ -101,9 +98,7 @@
     {{ title_prefix }}
     {% if label and not page %}
       <h3{{ title_attributes.addClass('cd-teaser__title') }}>
-        {% if showPage is same as '1' %}
-          <a href="{{ url }}" rel="bookmark">{{ label }}</a>
-        {% elseif showPage is same as '0' and fileURL is null %}
+        {% if showPage %}
           <a href="{{ url }}" rel="bookmark">{{ label }}</a>
         {% else %}
           <a href="{{ fileUrl }}" title="Download">{{ label }}</a>

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--title.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--title.html.twig
@@ -81,7 +81,8 @@
 ]
 %}
 {{ attach_library('common_design/cd-bullet-list') }}
-{% set fileUrl = file_url(content.field_media_files[0]['#media'].field_media_file.entity.uri.value) %}
+
+{% set fileUrl = node.field_media_files.0.entity.uri.value ? file_url(node.field_media_files.0.entity.uri.value) : url  %}
 {% set showPage = node.field_oa_wiki_page_no_redirect.0.value %}
 
 <article{{ attributes.addClass(classes) }}>


### PR DESCRIPTION
As per https://humanitarian.atlassian.net/browse/IASC-725?focusedCommentId=133975 this fixes the issue introduced in D9.3.3 https://www.drupal.org/project/drupal/issues/3254245 but doesn't work with the "Show page instead of file?" field on the Document node content type.
This means those nodes where the checkbox is selected will now lead to the full Node instead of a direct file download.