### PR TITLE
IASC-725 Get media file URL to use in template override

### DIFF
--- a/html/themes/custom/iasc_common_design/iasc_common_design.theme
+++ b/html/themes/custom/iasc_common_design/iasc_common_design.theme
@@ -134,7 +134,7 @@ function iasc_common_design_preprocess_node(&$variables) {
 
     if (!empty($document_file)) {
       $entity = Media::load($document_file[0]['target_id']);
-      $variables['$document_file'] = $entity->field_media_file->entity->getFileUri();
+      $variables['document_file'] = $entity->field_media_file->entity->getFileUri();
     }
 
     dpm($variables['$document_file']);

--- a/html/themes/custom/iasc_common_design/iasc_common_design.theme
+++ b/html/themes/custom/iasc_common_design/iasc_common_design.theme
@@ -137,7 +137,7 @@ function iasc_common_design_preprocess_node(&$variables) {
       $variables['document_file'] = $entity->field_media_file->entity->getFileUri();
     }
 
-    dpm($variables['$document_file']);
+    dpm($variables['document_file']);
   }
 }
 

--- a/html/themes/custom/iasc_common_design/iasc_common_design.theme
+++ b/html/themes/custom/iasc_common_design/iasc_common_design.theme
@@ -129,7 +129,7 @@ function iasc_common_design_preprocess_node(&$variables) {
 
   $bundle = $node->bundle();
 
-  if ($bundle == 'oa_wiki_page' && $variables['elements']['#view_mode'] == 'teaser') {
+  if ($bundle == 'oa_wiki_page' && ($variables['elements']['#view_mode'] == 'teaser' || $variables['elements']['#view_mode'] == 'title')) {
     $document_file = $node->get('field_media_files')->getValue();
 
     if (!empty($document_file)) {

--- a/html/themes/custom/iasc_common_design/iasc_common_design.theme
+++ b/html/themes/custom/iasc_common_design/iasc_common_design.theme
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\media\Entity\Media;
 
 /**
  * Implements template_preprocess_field().
@@ -124,6 +125,19 @@ function iasc_common_design_preprocess_node(&$variables) {
     else {
       $variables['event_time']['output'] = $variables['event_time']['start'] . ' — ' . $variables['event_time']['end'] . ' (' . $variables['event_time']['timezone'] . ')';
     }
+  }
+
+  $bundle = $node->bundle();
+
+  if ($bundle == 'oa_wiki_page' && $variables['elements']['#view_mode'] == 'teaser') {
+    $document_file = $node->get('field_media_files')->getValue();
+
+    if (!empty($document_file)) {
+      $entity = Media::load($document_file[0]['target_id']);
+      $variables['$document_file'] = $entity->field_media_file->entity->getFileUri();
+    }
+
+    dpm($variables['$document_file']);
   }
 }
 

--- a/html/themes/custom/iasc_common_design/iasc_common_design.theme
+++ b/html/themes/custom/iasc_common_design/iasc_common_design.theme
@@ -136,8 +136,6 @@ function iasc_common_design_preprocess_node(&$variables) {
       $entity = Media::load($document_file[0]['target_id']);
       $variables['document_file'] = $entity->field_media_file->entity->createFileUrl();
     }
-
-    dpm($variables['document_file']);
   }
 }
 

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--teaser.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--teaser.html.twig
@@ -83,7 +83,6 @@
 %}
 {{ attach_library('common_design/cd-teaser') }}
 
-{% set fileUrl = node.field_media_files.0.entity.uri.value ? file_url(node.field_media_files.0.entity.uri.value) :  url  %}
 {% set showPage = node.field_oa_wiki_page_no_redirect.0.value %}
 
 {{ dpm(showPage) }}
@@ -105,7 +104,7 @@
         {% if showPage %}
           <a href="{{ url }}" rel="bookmark">{{ label }}</a>
         {% else %}
-          <a href="{{ fileUrl }}" title="Download">{{ label }}</a>
+          <a href="{{ document_file }}" title="Download">{{ label }}</a>
         {% endif %}
       </h3>
     {% endif %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--teaser.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--teaser.html.twig
@@ -86,6 +86,10 @@
 {% set fileUrl = node.field_media_files.0.entity.uri.value ? file_url(node.field_media_files.0.entity.uri.value) :  url  %}
 {% set showPage = node.field_oa_wiki_page_no_redirect.0.value %}
 
+{{ dpm(showPage) }}
+{{ dpm(document_file) }}
+{{ dpm() }}
+
 <article{{ attributes.addClass(classes) }}>
 
   {% if content.field_thumbnail|render %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--title.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--title.html.twig
@@ -72,13 +72,13 @@
 #}
 {%
   set classes = [
-  'node',
-  'node--type-' ~ node.bundle|clean_class,
-  node.isPromoted() ? 'node--promoted',
-  node.isSticky() ? 'node--sticky',
-  not node.isPublished() ? 'node--unpublished',
-  view_mode ? 'node--view-mode-' ~ view_mode|clean_class
-]
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class
+  ]
 %}
 {{ attach_library('common_design/cd-bullet-list') }}
 

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--title.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--title.html.twig
@@ -82,7 +82,6 @@
 %}
 {{ attach_library('common_design/cd-bullet-list') }}
 
-{% set fileUrl = document_file  %}
 {% set showPage = node.field_oa_wiki_page_no_redirect.0.value %}
 
 {{ dpm(showPage) }}
@@ -95,7 +94,7 @@
   {% if showPage %}
     <a href="{{ url }}" rel="bookmark">
   {% else %}
-    <a href="{{ fileUrl }}" title="Download">
+    <a href="{{ document_file }}" title="Download">
   {% endif %}
       {{ label }}
     </a>

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--title.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--title.html.twig
@@ -82,8 +82,12 @@
 %}
 {{ attach_library('common_design/cd-bullet-list') }}
 
-{% set fileUrl = node.field_media_files.0.entity.uri.value ? file_url(node.field_media_files.0.entity.uri.value) : url  %}
+{% set fileUrl = document_file  %}
 {% set showPage = node.field_oa_wiki_page_no_redirect.0.value %}
+
+{{ dpm(showPage) }}
+{{ dpm(document_file) }}
+{{ dpm() }}
 
 <article{{ attributes.addClass(classes) }}>
 


### PR DESCRIPTION
See IASC-725 recent comments.

This provides the file URL as a variable to use in the Document node teaser and node title template override file conditional statement so the Node title is a link to the file download when the "Show page instead of file?"  is unchecked.