### PR TITLE
IASC-732 Display OCHA Services when user menu is disabled

### DIFF
--- a/html/themes/custom/iasc_common_design/templates/region/region--header-top.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/region/region--header-top.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Theme override to display a region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
+
+{%
+  set classes = [
+  'region',
+  'region-' ~ region|clean_class,
+  'cd-global-header__actions'
+]
+%}
+<div{{ attributes.addClass(classes).setAttribute('id', 'cd-global-header__actions') }}>
+  {{ content }}
+</div>


### PR DESCRIPTION
When the user menu items are disabled, the OCHA Services fails to display in the global header as it should. Instead it is in the footer because the javascript that moves the OCHA Services to the global header is reliant on the `cd-global-header__actions` div which doesn't display if there is no content due to the div in the region template being wrapped in the `{% if content %}` conditional. This can currently be seen on Prod https://interagencystandingcommittee.org/

I've added an override for the header top region template to remove the conditional so div displays even when user menu items are disabled.

Refs: IASC-732