### PR TITLE
IASC-732 disable user menu items in config

### DIFF
--- a/config/core.menu.static_menu_link_overrides.yml
+++ b/config/core.menu.static_menu_link_overrides.yml
@@ -91,3 +91,9 @@ definitions:
     weight: 100
     expanded: false
     enabled: false
+  user__logout:
+    enabled: false
+    menu_name: account
+    parent: ''
+    weight: 10
+    expanded: false


### PR DESCRIPTION
After a Prod deploy, the user menu item for Login is back. This is the config to disable it.