### PR TITLE
fix: apply committed patch for search_api_solr

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,34 +1,37 @@
 {
-    "patches": {
-        "drupal/core": {
-          "https://www.drupal.org/project/drupal/issues/1819538#comment-14019597 - More link disappears when time-based views cache is enabled": "https://www.drupal.org/files/issues/2021-03-05/1819538-57-D9.patch",
-          "https://www.drupal.org/project/drupal/issues/2833734 - Allow views attachment display use own pager options": "https://www.drupal.org/files/issues/2020-11-29/2833734-allow-attachment-pager-42.patch",
-          "https://www.drupal.org/project/drupal/issues/2628230#comment-13213379 - Adding File Usage 'File' relationship results in broken/missing handler": "https://www.drupal.org/files/issues/2019-08-08/2628230-53.patch"
-        },
-        "drupal/csp": {
-            "Simplify log format": "PATCHES/csp-log-format.patch"
-        },
-        "drupal/group": {
-          "https://www.drupal.org/project/group/issues/2817109 - How to redirect to the owning group after adding a gnode?": "https://www.drupal.org/files/issues/2817109-by-rachel_norfolk-ericras-How-to-redir.patch"
-        },
-        "drupal/paragraphs": {
-          "https://www.drupal.org/project/paragraphs/issues/2868252#comment-13622986": "https://www.drupal.org/files/issues/2020-05-20/i2868252-28.patch"
-        },
-        "drupal/search_api": {
-          "https://www.drupal.org/project/search_api/issues/3130004 - Facets query part is lost in views": "https://git.drupalcode.org/project/search_api/-/merge_requests/8.diff"
-        },
-        "drupal/select_a11y": {
-          "Patch the contrib v1.0.1 module so the code matches what used to be in custom": "PATCHES/select_a11ly.patch"
-        },
-        "drupal/user_expire": {
-          "Allow the notification email to be customised": "https://git.drupalcode.org/project/user_expire/-/merge_requests/5.diff",
-          "Reset expiration when user is reactivated": "https://git.drupalcode.org/project/user_expire/-/merge_requests/6.diff"
-        },
-        "drupal/views_data_export": {
-          "https://www.drupal.org/project/views_data_export/issues/3173296": "https://www.drupal.org/files/issues/2021-02-12/3173296-9-batch-query-alter.patch"
-        },
-        "drupal/viewsreference": {
-          "https://dgo.to/3166490 - Trigger ajax refresh when display ID is changed": "https://www.drupal.org/files/issues/2020-09-02/viewsreference-ajax_after_display_selection-3166490-3.patch"
-        }
+  "patches": {
+    "drupal/core": {
+      "https://www.drupal.org/project/drupal/issues/1819538#comment-14019597 - More link disappears when time-based views cache is enabled": "https://www.drupal.org/files/issues/2021-03-05/1819538-57-D9.patch",
+      "https://www.drupal.org/project/drupal/issues/2833734 - Allow views attachment display use own pager options": "https://www.drupal.org/files/issues/2020-11-29/2833734-allow-attachment-pager-42.patch",
+      "https://www.drupal.org/project/drupal/issues/2628230#comment-13213379 - Adding File Usage 'File' relationship results in broken/missing handler": "https://www.drupal.org/files/issues/2019-08-08/2628230-53.patch"
+    },
+    "drupal/csp": {
+      "Simplify log format": "PATCHES/csp-log-format.patch"
+    },
+    "drupal/group": {
+      "https://www.drupal.org/project/group/issues/2817109 - How to redirect to the owning group after adding a gnode?": "https://www.drupal.org/files/issues/2817109-by-rachel_norfolk-ericras-How-to-redir.patch"
+    },
+    "drupal/paragraphs": {
+      "https://www.drupal.org/project/paragraphs/issues/2868252#comment-13622986": "https://www.drupal.org/files/issues/2020-05-20/i2868252-28.patch"
+    },
+    "drupal/search_api": {
+      "https://www.drupal.org/project/search_api/issues/3130004 - Facets query part is lost in views": "https://git.drupalcode.org/project/search_api/-/merge_requests/8.diff"
+    },
+    "drupal/search_api_solr": {
+      "#3314711-21: empty specific languages": "https://www.drupal.org/files/issues/2022-10-24/search_api_solr-empty-specific-languages-3314711-21.patch"
+    },
+    "drupal/select_a11y": {
+      "Patch the contrib v1.0.1 module so the code matches what used to be in custom": "PATCHES/select_a11ly.patch"
+    },
+    "drupal/user_expire": {
+      "Allow the notification email to be customised": "https://git.drupalcode.org/project/user_expire/-/merge_requests/5.diff",
+      "Reset expiration when user is reactivated": "https://git.drupalcode.org/project/user_expire/-/merge_requests/6.diff"
+    },
+    "drupal/views_data_export": {
+      "https://www.drupal.org/project/views_data_export/issues/3173296": "https://www.drupal.org/files/issues/2021-02-12/3173296-9-batch-query-alter.patch"
+    },
+    "drupal/viewsreference": {
+      "https://dgo.to/3166490 - Trigger ajax refresh when display ID is changed": "https://www.drupal.org/files/issues/2020-09-02/viewsreference-ajax_after_display_selection-3166490-3.patch"
     }
+  }
 }


### PR DESCRIPTION
Refs: OPS-8623

Doesn't seem to be needed, and will be included anyway when search_api_solr module is updated (when the patch should be removed), but it fixed an issue with Docstore and is now on AR, so including here for consistency