### PR TITLE
chore: Use the normal PHP image for the build.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/unocha/unified-builder:8.0-stable as builder
+FROM public.ecr.aws/unocha/php-k8s:8.0-stable as builder
 ARG  BRANCH_ENVIRONMENT
 ENV  NODE_ENV=$BRANCH_ENVIRONMENT
 COPY . /srv/www


### PR DESCRIPTION
The builder is no longer maintained, since the current common_design theme no longer requires sass to build assets.

Refs: OPS-9161