### PR TITLE
chore: unpin colors module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/address": "^1.6",
         "drupal/admin_denied": "^2",
         "drupal/chosen": "^3.0",
-        "drupal/colors": "1.x-dev",
+        "drupal/colors": "^1.0@beta",
         "drupal/components": "^2.4",
         "drupal/conditional_fields": "^4.0@alpha",
         "drupal/config_split": "^2.0.0-beta4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e801e512091c61da45a165bbe917478",
+    "content-hash": "4004da420e998a5b52a04d4b55c48fbc",
     "packages": [
         {
             "name": "algolia/places",
@@ -1999,26 +1999,29 @@
         },
         {
             "name": "drupal/colors",
-            "version": "dev-1.x",
+            "version": "1.0.0-beta1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/colors.git",
-                "reference": "3d64b1d44f96836ff8a52fb68b1f7d17f95ab161"
+                "reference": "8.x-1.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/colors-8.x-1.0-beta1.zip",
+                "reference": "8.x-1.0-beta1",
+                "shasum": "42f306d4aa05d6e2d145bb20de7fcdaa71f04b30"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-1.x-dev",
-                    "datestamp": "1587391409",
+                    "version": "8.x-1.0-beta1",
+                    "datestamp": "1587410367",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
+                        "message": "Beta releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -19717,7 +19720,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "drupal/colors": 20,
+        "drupal/colors": 10,
         "drupal/conditional_fields": 15,
         "drupal/config_split": 10,
         "drupal/diff": 5,
@@ -19742,5 +19745,5 @@
         "php": ">=8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Refs: OPS-9403

Not really sure what colors is for (the project page states: "A generic color-coding API. More information and documentation to follow."), or whether it will be updated to have a D10 compatible version.

Also not sure if we're using it - there's no mention of the string 'colors' in 'html/modules/custom' directory, or in 'config' directory, and the mentions of that string in 'html/themes/custom' don't refer to this module. It's also never been enabled, though there was a 'color' module, which was removed last year https://humanitarian.atlassian.net/browse/OPS-8561

This just unpins it, but we might want to look at removing it. I'll make another ticket to do that.