### PR TITLE
chore: remove colors module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "drupal/address": "^1.6",
         "drupal/admin_denied": "^2",
         "drupal/chosen": "^3.0",
-        "drupal/colors": "1.x-dev",
         "drupal/components": "^2.4",
         "drupal/conditional_fields": "^4.0@alpha",
         "drupal/config_split": "^2.0.0-beta4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e801e512091c61da45a165bbe917478",
+    "content-hash": "e927d32bcef7d0a1bf516fda1383976d",
     "packages": [
         {
             "name": "algolia/places",
@@ -1995,59 +1995,6 @@
             "homepage": "https://www.drupal.org/project/chosen",
             "support": {
                 "source": "https://git.drupalcode.org/project/chosen"
-            }
-        },
-        {
-            "name": "drupal/colors",
-            "version": "dev-1.x",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/colors.git",
-                "reference": "3d64b1d44f96836ff8a52fb68b1f7d17f95ab161"
-            },
-            "require": {
-                "drupal/core": "^8 || ^9"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-1.x-dev",
-                    "datestamp": "1587391409",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Unsupported Projects",
-                    "homepage": "https://www.drupal.org/user/291168"
-                },
-                {
-                    "name": "aspilicious",
-                    "homepage": "https://www.drupal.org/user/172527"
-                },
-                {
-                    "name": "dakala",
-                    "homepage": "https://www.drupal.org/user/53175"
-                },
-                {
-                    "name": "fubhy",
-                    "homepage": "https://www.drupal.org/user/761344"
-                }
-            ],
-            "description": "API for coloring selectors",
-            "homepage": "https://www.drupal.org/project/colors",
-            "support": {
-                "source": "https://git.drupalcode.org/project/colors"
             }
         },
         {
@@ -19717,7 +19664,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "drupal/colors": 20,
         "drupal/conditional_fields": 15,
         "drupal/config_split": 10,
         "drupal/diff": 5,


### PR DESCRIPTION
Refs: OPS-9403

To go beyond un-pinning the colors module, https://github.com/UN-OCHA/iasc8/pull/817, I think we can remove it.

Also, it's minimally maintained and not ready for D10.