### PR TITLE
[OPS-9660] More sidebar love

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -14,7 +14,7 @@ jobs:
       uses: UN-OCHA/actions/composer-update@main
       with:
         github_access_token: ${{ secrets.PAT }}
-        patch_branch: 'develop'
+        patch_branch: ${{ github.ref_name }}
         patch_packages: 'drupal/*'
         patch_maintainers: ${{ secrets.DRUPAL_MAINTAINERS }}
         slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -144,6 +144,8 @@ jobs:
             docker compose -f tests/docker-compose.yml exec -T drupal chmod -R 777 /srv/www/coverage
             docker compose -f tests/docker-compose.yml exec -T drupal mkdir -p /srv/www/html/sites/simpletest
             docker compose -f tests/docker-compose.yml exec -T drupal chmod -R 777 /srv/www/html/sites/simpletest
+            docker compose -f tests/docker-compose.yml exec -T drupal touch /srv/www/.phpunit.result.cache
+            docker compose -f tests/docker-compose.yml exec -T drupal chmod 777 /srv/www/.phpunit.result.cache
             docker compose -f tests/docker-compose.yml exec -u appuser -T -w /srv/www -e XDEBUG_MODE=coverage -e BROWSERTEST_OUTPUT_DIRECTORY=/srv/www/html/sites/default/files/browser_output -e DTT_BASE_URL=http://127.0.0.1 -e SIMPLETEST_BASE_URL=http://127.0.0.1 drupal ./vendor/bin/phpunit --coverage-clover /srv/www/html/build/logs/clover.xml --debug
         env:
           fail-fast: true

--- a/config/core.entity_view_display.paragraph.contact_list.default.yml
+++ b/config/core.entity_view_display.paragraph.contact_list.default.yml
@@ -18,7 +18,7 @@ content:
       view_mode: bio_short
       link: false
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
   field_list_title:
     type: string
@@ -26,7 +26,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 1
+    weight: 0
     region: content
 hidden:
   search_api_excerpt: true

--- a/html/themes/custom/iasc_common_design/components/cd-list/cd-list.css
+++ b/html/themes/custom/iasc_common_design/components/cd-list/cd-list.css
@@ -4,9 +4,8 @@
   list-style: none;
 }
 
-/* Override the generic .cd-layout__sidebar--first ul */
-.cd-layout__sidebar--first .cd-list,
-.cd-layout__sidebar--second .cd-list {
+/* Override the generic .cd-layout__sidebar ul */
+.cd-layout__sidebar .cd-list {
   margin: 0;
   padding-inline-start: 0;
 }
@@ -118,22 +117,22 @@
 }
 
 @media (min-width: 767px) {
-  .cd-layout__sidebar--first .cd-list li {
+  .cd-layout__sidebar .cd-list li {
     flex-wrap: wrap;
   }
 
-  .cd-layout__sidebar--first .cd-list__image {
+  .cd-layout__sidebar .cd-list__image {
     width: 3rem;
     max-height: 3rem;
     padding-right: 1rem;
   }
 
-  .cd-layout__sidebar--first .cd-list__footer {
+  .cd-layout__sidebar .cd-list__footer {
     display: block;
     flex: 1 0 100%;
   }
 
-  .cd-layout__sidebar--first .cd-list__link {
+  .cd-layout__sidebar .cd-list__link {
     padding-left: 0;
     text-align: right;
   }

--- a/html/themes/custom/iasc_common_design/components/cd-styled-list/cd-styled-list.css
+++ b/html/themes/custom/iasc_common_design/components/cd-styled-list/cd-styled-list.css
@@ -7,7 +7,7 @@
   height: auto;
 }
 
-/* Override the generic .cd-layout__sidebar--first ul */
-.cd-layout__sidebar--first .cd-styled-list li {
+/* Override the generic .cd-layout__sidebar ul */
+.cd-layout__sidebar .cd-styled-list li {
   margin-top: 0;
 }

--- a/html/themes/custom/iasc_common_design/components/cd-teaser/cd-teaser.css
+++ b/html/themes/custom/iasc_common_design/components/cd-teaser/cd-teaser.css
@@ -1,8 +1,8 @@
-.cd-layout__sidebar--first .cd-teaser__image {
+.cd-layout__sidebar .cd-teaser__image {
   float: none;
 }
 
-.cd-layout__sidebar--first .cd-teaser__image + .cd-teaser__container {
+.cd-layout__sidebar .cd-teaser__image + .cd-teaser__container {
   padding: 0;
 }
 

--- a/html/themes/custom/iasc_common_design/components/iasc-cd-header-footer/cd-layout.css
+++ b/html/themes/custom/iasc_common_design/components/iasc-cd-header-footer/cd-layout.css
@@ -1,11 +1,11 @@
 /* Assumes frontpage has hero as first element in header field. */
 @supports (object-fit: cover) {
-  .path-frontpage:not(.user-logged-in) .cd-layout-container main.cd-container {
+  .path-frontpage:not(.user-logged-in) .cd-page-layout-container main.cd-container {
     /* Hack for IE11. Hero component covers search so we want the padding to make it usable in IE11. */
     padding-top: 0;
   }
 }
 
-.path-frontpage:not(.user-logged-in) .cd-layout-container main.cd-container .cd-layout .cd-layout__content iframe {
+.path-frontpage:not(.user-logged-in) .cd-page-layout-container main.cd-container .cd-layout .cd-layout__content iframe {
   max-width: 100%;
 }

--- a/html/themes/custom/iasc_common_design/components/iasc-custom/field.css
+++ b/html/themes/custom/iasc_common_design/components/iasc-custom/field.css
@@ -57,20 +57,20 @@
   margin-bottom: 1rem;
 }
 
-.cd-layout__sidebar--first .cd-location,
-.cd-layout__sidebar--first .field--name-field-meeting-notes,
-.cd-layout__sidebar--first .field--name-field-meeting-agendas,
-.cd-layout__sidebar--first .field--name-field-oa-section,
-.cd-layout__sidebar--first .field--name-field-iasc-audience,
-.cd-layout__sidebar--first .field--name-field-links,
-.cd-layout__sidebar--first .field--name-field-membership,
-.cd-layout__sidebar--first .field--name-field-date-closed,
-.cd-layout__sidebar--first .field--name-field-external-link,
-.cd-layout__sidebar--first .field--name-group-content-access,
-.cd-layout__sidebar--first .field--name-field-ap-responsibility,
-.cd-layout__sidebar--first .field--name-field-referenced-docs,
-.cd-layout__sidebar--first .field--name-field-host,
-.cd-layout__sidebar--first .field--name-field-category {
+.cd-layout__sidebar .cd-location,
+.cd-layout__sidebar .field--name-field-meeting-notes,
+.cd-layout__sidebar .field--name-field-meeting-agendas,
+.cd-layout__sidebar .field--name-field-oa-section,
+.cd-layout__sidebar .field--name-field-iasc-audience,
+.cd-layout__sidebar .field--name-field-links,
+.cd-layout__sidebar .field--name-field-membership,
+.cd-layout__sidebar .field--name-field-date-closed,
+.cd-layout__sidebar .field--name-field-external-link,
+.cd-layout__sidebar .field--name-group-content-access,
+.cd-layout__sidebar .field--name-field-ap-responsibility,
+.cd-layout__sidebar .field--name-field-referenced-docs,
+.cd-layout__sidebar .field--name-field-host,
+.cd-layout__sidebar .field--name-field-category {
   margin-bottom: 2rem !important;
 }
 
@@ -89,7 +89,7 @@
   margin-bottom: 0;
 }
 
-.cd-layout__sidebar--first > .cd-sidebar {
+.cd-layout__sidebar > .cd-sidebar {
   margin-bottom: 1rem !important;
 }
 
@@ -152,11 +152,11 @@
 }
 
 /* AAP Services fields in sidebar */
-.cd-layout__sidebar--first .field--name-field-updated,
-.cd-layout__sidebar--first .field--name-field-agency-initiative-or-group,
-.cd-layout__sidebar--first .field--name-field-type-of-entity,
-.cd-layout__sidebar--first .field--name-field-focal-point,
-.cd-layout__sidebar--first .field--name-field-featured-categories {
+.cd-layout__sidebar .field--name-field-updated,
+.cd-layout__sidebar .field--name-field-agency-initiative-or-group,
+.cd-layout__sidebar .field--name-field-type-of-entity,
+.cd-layout__sidebar .field--name-field-focal-point,
+.cd-layout__sidebar .field--name-field-featured-categories {
   margin-bottom: 2rem;
 }
 

--- a/html/themes/custom/iasc_common_design/components/iasc-custom/node.css
+++ b/html/themes/custom/iasc_common_design/components/iasc-custom/node.css
@@ -61,7 +61,7 @@
   margin-bottom: 2rem;
 }
 
-.path-frontpage .cd-layout__sidebar--first .viewsreference--view-title {
+.path-frontpage .cd-layout__sidebar .viewsreference--view-title {
   margin-top: 1rem;
 }
 
@@ -97,6 +97,6 @@
   margin-bottom: 0.5rem;
 }
 
-.node--type-service.node--view-mode-full .cd-layout__sidebar--first textarea {
+.node--type-service.node--view-mode-full .cd-layout__sidebar textarea {
   width: 100%;
 }

--- a/html/themes/custom/iasc_common_design/components/iasc-custom/paragraph.css
+++ b/html/themes/custom/iasc_common_design/components/iasc-custom/paragraph.css
@@ -39,9 +39,9 @@
   background-size: 0.5rem 0.5rem;
 }
 
-/* Override the generic .cd-layout__sidebar--first ul */
-.cd-layout__sidebar--first .paragraph--type--paragraph-content ul li,
-.cd-layout__sidebar--first .paragraph--type--paragraph-text ul li {
+/* Override the generic .cd-layout__sidebar ul */
+.cd-layout__sidebar .paragraph--type--paragraph-content ul li,
+.cd-layout__sidebar .paragraph--type--paragraph-text ul li {
   margin-top: 0;
 }
 
@@ -140,9 +140,9 @@
   margin-bottom: 2rem;
 }
 
-.cd-layout__sidebar--first .cd-sidebar__label,
-.cd-layout__sidebar--first .paragraph--type--list > h2,
-.cd-layout__sidebar--first .paragraph--type--teaser-grid > h2 {
+.cd-layout__sidebar .cd-sidebar__label,
+.cd-layout__sidebar .paragraph--type--list > h2,
+.cd-layout__sidebar .paragraph--type--teaser-grid > h2 {
   margin-top: 0;
 }
 
@@ -168,36 +168,36 @@ aside .paragraph--type--content-item .group--view-mode-teaser .cd-teaser__image 
   max-width: 100%;
 }
 
-.cd-layout__sidebar--first .paragraph--type--content-item .field--name-field-category {
+.cd-layout__sidebar .paragraph--type--content-item .field--name-field-category {
   margin-bottom: 1rem !important;
 }
 
-.cd-layout__sidebar--first .paragraph--type--teaser-grid .cd-grid > * {
+.cd-layout__sidebar .paragraph--type--teaser-grid .cd-grid > * {
   flex: 0 0 100%;
 }
 
-.cd-layout__sidebar--first .paragraph--type--teaser-grid .cd-grid .field--type-entity-reference-revisions .paragraph--type--teaser-item {
+.cd-layout__sidebar .paragraph--type--teaser-grid .cd-grid .field--type-entity-reference-revisions .paragraph--type--teaser-item {
   padding: 0;
 }
 
 @supports (display: grid) {
-  .cd-layout__sidebar--first .paragraph--type--teaser-grid .cd-grid {
+  .cd-layout__sidebar .paragraph--type--teaser-grid .cd-grid {
     grid-template-columns: repeat(1, minmax(200px, 1fr));
   }
 }
 
-.cd-layout__sidebar--first .paragraph--type--teaser-grid .field__item:last-child .paragraph--type--teaser-item {
+.cd-layout__sidebar .paragraph--type--teaser-grid .field__item:last-child .paragraph--type--teaser-item {
   margin-bottom: 0;
 }
 
-.cd-layout__sidebar--first .paragraph--type--teaser-grid,
-.cd-layout__sidebar--first .paragraph--type--paragraph-text,
-.cd-layout__sidebar--first .paragraph--type--video,
-.cd-layout__sidebar--first .paragraph--type--paragraph-content {
+.cd-layout__sidebar .paragraph--type--teaser-grid,
+.cd-layout__sidebar .paragraph--type--paragraph-text,
+.cd-layout__sidebar .paragraph--type--video,
+.cd-layout__sidebar .paragraph--type--paragraph-content {
   margin-bottom: 2rem;
 }
 
-.cd-layout__sidebar--first .paragraph--type--contact-list {
+.cd-layout__sidebar .paragraph--type--contact-list {
   margin-bottom: 1rem;
 }
 

--- a/html/themes/custom/iasc_common_design/templates/group/group.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/group/group.html.twig
@@ -93,7 +93,7 @@
           {{ content.field_content }}
         </div>
 
-        <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide">
+        <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">
           {% if user.hasPermission('administer nodes') %}
           <div class="paragraph-quick-links paragraph--type--section-menu">
             <h2 class="cd-sidebar__label cd-block-title cd-block-title--underline">Quick links</h2>

--- a/html/themes/custom/iasc_common_design/templates/group/group.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/group/group.html.twig
@@ -93,7 +93,7 @@
           {{ content.field_content }}
         </div>
 
-        <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">
+        <aside class="cd-layout__sidebar cd-layout__sidebar--second">
           {% if user.hasPermission('administer nodes') %}
           <div class="paragraph-quick-links paragraph--type--section-menu">
             <h2 class="cd-sidebar__label cd-block-title cd-block-title--underline">Quick links</h2>

--- a/html/themes/custom/iasc_common_design/templates/layout/page--group--documents.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--group--documents.html.twig
@@ -12,7 +12,7 @@
 
       <div class="cd-layout">
         {% if page.sidebar_first|render or page.facets|render %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page--group--documents.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--group--documents.html.twig
@@ -12,7 +12,7 @@
 
       <div class="cd-layout">
         {% if page.sidebar_first|render or page.facets|render %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page--group--meetings.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--group--meetings.html.twig
@@ -12,7 +12,7 @@
 
       <div class="cd-layout">
         {% if page.sidebar_first|render|striptags|trim %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page--group--meetings.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--group--meetings.html.twig
@@ -12,7 +12,7 @@
 
       <div class="cd-layout">
         {% if page.sidebar_first|render|striptags|trim %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page--group--news.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--group--news.html.twig
@@ -12,7 +12,7 @@
 
       <div class="cd-layout">
         {% if page.sidebar_first|render|striptags|trim %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page--group--news.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--group--news.html.twig
@@ -12,7 +12,7 @@
 
       <div class="cd-layout">
         {% if page.sidebar_first|render|striptags|trim %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page--group.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--group.html.twig
@@ -89,7 +89,7 @@
 
       <div class="cd-layout">
         {% if page.sidebar_first|render|striptags|trim %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page--group.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--group.html.twig
@@ -89,7 +89,7 @@
 
       <div class="cd-layout">
         {% if page.sidebar_first|render|striptags|trim %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page--group.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--group.html.twig
@@ -53,7 +53,7 @@
 {% block attach %}
 {% endblock %}
 
-<div class="cd-layout-container">
+<div class="cd-page-layout-container">
 
   {% block header %}
     {% include '@iasc_common_design/cd/cd-header/cd-header.html.twig' %}
@@ -114,4 +114,4 @@
   {% endblock %}
 
 
-</div>{# /.cd-layout-container #}
+</div>{# /.cd-page-layout-container #}

--- a/html/themes/custom/iasc_common_design/templates/layout/page--rg2.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--rg2.html.twig
@@ -22,7 +22,7 @@
       <div class="cd-layout-content-wrapper">
 
           {% if (page.sidebar_first|render|striptags|trim) or page.facets %}
-            <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ page.facets }}{{ page.sidebar_first }}</aside>
+            <aside class="cd-layout__sidebar cd-layout__sidebar--second" aria-label="{{ 'Sidebar'| }}">{{ page.facets }}{{ page.sidebar_first }}</aside>
           {% endif %}
 
           <div class="cd-layout-content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page--rg2.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--rg2.html.twig
@@ -22,7 +22,7 @@
       <div class="cd-layout-content-wrapper">
 
           {% if (page.sidebar_first|render|striptags|trim) or page.facets %}
-            <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ page.facets }}{{ page.sidebar_first }}</aside>
+            <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ page.facets }}{{ page.sidebar_first }}</aside>
           {% endif %}
 
           <div class="cd-layout-content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page--rg2.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page--rg2.html.twig
@@ -22,7 +22,7 @@
       <div class="cd-layout-content-wrapper">
 
           {% if (page.sidebar_first|render|striptags|trim) or page.facets %}
-            <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">{{ page.facets }}{{ page.sidebar_first }}</aside>
+            <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ page.facets }}{{ page.sidebar_first }}</aside>
           {% endif %}
 
           <div class="cd-layout-content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page.html.twig
@@ -99,7 +99,7 @@
 
       <div class="cd-layout">
         {% if page.sidebar_first|render|striptags|trim %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/html/themes/custom/iasc_common_design/templates/layout/page.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/layout/page.html.twig
@@ -99,7 +99,7 @@
 
       <div class="cd-layout">
         {% if page.sidebar_first|render|striptags|trim %}
-          <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide">{{ page.sidebar_first }}</aside>
+          <aside class="cd-layout__sidebar cd-layout__sidebar--second">{{ page.sidebar_first }}</aside>
         {% endif %}
 
         <div class="cd-layout__content">

--- a/html/themes/custom/iasc_common_design/templates/node/node--action-point--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--action-point--full.html.twig
@@ -8,7 +8,7 @@
           {{ content.field_content }}
         </div>
 
-        <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">
+        <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">
           {{ content.og_group_ref }}
           {{ content.group_content_access }}
           {{ content.field_iasc_audience }}

--- a/html/themes/custom/iasc_common_design/templates/node/node--action-point--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--action-point--full.html.twig
@@ -8,7 +8,7 @@
           {{ content.field_content }}
         </div>
 
-        <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">
+        <aside class="cd-layout__sidebar cd-layout__sidebar--second" aria-label="{{ 'Sidebar'| }}">
           {{ content.og_group_ref }}
           {{ content.group_content_access }}
           {{ content.field_iasc_audience }}

--- a/html/themes/custom/iasc_common_design/templates/node/node--action-point--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--action-point--full.html.twig
@@ -8,7 +8,7 @@
           {{ content.field_content }}
         </div>
 
-        <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">
+        <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">
           {{ content.og_group_ref }}
           {{ content.group_content_access }}
           {{ content.field_iasc_audience }}

--- a/html/themes/custom/iasc_common_design/templates/node/node--announcement--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--announcement--full.html.twig
@@ -9,7 +9,7 @@
         {{ content.field_referenced_docs }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">{{ content.field_links }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ content.field_links }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
 
     </div>
   {% endblock %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--announcement--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--announcement--full.html.twig
@@ -9,7 +9,7 @@
         {{ content.field_referenced_docs }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ content.field_links }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" aria-label="{{ 'Sidebar'| }}">{{ content.field_links }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
 
     </div>
   {% endblock %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--announcement--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--announcement--full.html.twig
@@ -9,7 +9,7 @@
         {{ content.field_referenced_docs }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ content.field_links }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ content.field_links }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
 
     </div>
   {% endblock %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--contact--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--contact--full.html.twig
@@ -9,7 +9,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ content.field_membership }}{{ content.field_organisation }}{{ content.field_sidebar }}</aside>
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" aria-label="{{ 'Sidebar'| }}">{{ content.field_membership }}{{ content.field_organisation }}{{ content.field_sidebar }}</aside>
       {% else %}
       <div class="cd-layout__content">
         <p>To view more details, please login.</p>

--- a/html/themes/custom/iasc_common_design/templates/node/node--contact--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--contact--full.html.twig
@@ -9,7 +9,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">{{ content.field_membership }}{{ content.field_organisation }}{{ content.field_sidebar }}</aside>
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ content.field_membership }}{{ content.field_organisation }}{{ content.field_sidebar }}</aside>
       {% else %}
       <div class="cd-layout__content">
         <p>To view more details, please login.</p>

--- a/html/themes/custom/iasc_common_design/templates/node/node--contact--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--contact--full.html.twig
@@ -9,7 +9,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ content.field_membership }}{{ content.field_organisation }}{{ content.field_sidebar }}</aside>
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ content.field_membership }}{{ content.field_organisation }}{{ content.field_sidebar }}</aside>
       {% else %}
       <div class="cd-layout__content">
         <p>To view more details, please login.</p>

--- a/html/themes/custom/iasc_common_design/templates/node/node--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--full.html.twig
@@ -140,7 +140,7 @@
           {{ content.field_content }}
         </div>
 
-        <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ content.field_section }}{{ content.field_category }}{{ content.og_group_ref }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
+        <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ content.field_section }}{{ content.field_category }}{{ content.og_group_ref }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
 
       </div>
     {% endblock %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--full.html.twig
@@ -140,7 +140,7 @@
           {{ content.field_content }}
         </div>
 
-        <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">{{ content.field_section }}{{ content.field_category }}{{ content.og_group_ref }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
+        <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ content.field_section }}{{ content.field_category }}{{ content.og_group_ref }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
 
       </div>
     {% endblock %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--full.html.twig
@@ -140,7 +140,7 @@
           {{ content.field_content }}
         </div>
 
-        <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ content.field_section }}{{ content.field_category }}{{ content.og_group_ref }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
+        <aside class="cd-layout__sidebar cd-layout__sidebar--second" aria-label="{{ 'Sidebar'| }}">{{ content.field_section }}{{ content.field_category }}{{ content.og_group_ref }}{{ content.field_contact }}{{ content.field_sidebar }}</aside>
 
       </div>
     {% endblock %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-event--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-event--full.html.twig
@@ -155,7 +155,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">
         {% if content.field_city|render or content.field_additional_locations|render or content.field_venue|render or content.field_room|render %}
           <div class="cd-location">
             <div class="cd-sidebar__label cd-block-title cd-block-title--underline">{% trans %}Location{% endtrans %}</div>

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-event--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-event--full.html.twig
@@ -155,7 +155,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" aria-label="{{ 'Sidebar'| }}">
         {% if content.field_city|render or content.field_additional_locations|render or content.field_venue|render or content.field_room|render %}
           <div class="cd-location">
             <div class="cd-sidebar__label cd-block-title cd-block-title--underline">{% trans %}Location{% endtrans %}</div>

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-event--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-event--full.html.twig
@@ -155,7 +155,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">
         {% if content.field_city|render or content.field_additional_locations|render or content.field_venue|render or content.field_room|render %}
           <div class="cd-location">
             <div class="cd-sidebar__label cd-block-title cd-block-title--underline">{% trans %}Location{% endtrans %}</div>

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-section--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-section--full.html.twig
@@ -8,7 +8,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" aria-label="{{ 'Sidebar'| }}">
         {{ content.field_oa_section }}
         {{ content.field_iasc_audience }}
         {{ content.field_sidebar }}

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-section--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-section--full.html.twig
@@ -8,7 +8,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">
         {{ content.field_oa_section }}
         {{ content.field_iasc_audience }}
         {{ content.field_sidebar }}

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-section--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-section--full.html.twig
@@ -8,7 +8,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">
         {{ content.field_oa_section }}
         {{ content.field_iasc_audience }}
         {{ content.field_sidebar }}

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--full.html.twig
@@ -8,7 +8,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ content.field_category }}{{ content.field_iasc_audience }}{{ content.field_sidebar }}</aside>
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" aria-label="{{ 'Sidebar'| }}">{{ content.field_category }}{{ content.field_iasc_audience }}{{ content.field_sidebar }}</aside>
 
     </div>
   {% endblock %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--full.html.twig
@@ -8,7 +8,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ content.field_category }}{{ content.field_iasc_audience }}{{ content.field_sidebar }}</aside>
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">{{ content.field_category }}{{ content.field_iasc_audience }}{{ content.field_sidebar }}</aside>
 
     </div>
   {% endblock %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--oa-wiki-page--full.html.twig
@@ -8,7 +8,7 @@
         {{ content.field_content }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">{{ content.field_category }}{{ content.field_iasc_audience }}{{ content.field_sidebar }}</aside>
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">{{ content.field_category }}{{ content.field_iasc_audience }}{{ content.field_sidebar }}</aside>
 
     </div>
   {% endblock %}

--- a/html/themes/custom/iasc_common_design/templates/node/node--service--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--service--full.html.twig
@@ -7,7 +7,7 @@
         {{ content|without('field_global_focal_point', 'field_updated', 'field_agency_initiative_or_group', 'field_type_of_entity') }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">
         {{ content.field_updated }}
         {{ content.field_agency_initiative_or_group }}
         {{ content.field_type_of_entity }}

--- a/html/themes/custom/iasc_common_design/templates/node/node--service--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--service--full.html.twig
@@ -7,7 +7,7 @@
         {{ content|without('field_global_focal_point', 'field_updated', 'field_agency_initiative_or_group', 'field_type_of_entity') }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--second" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second" aria-label="{{ 'Sidebar'| }}">
         {{ content.field_updated }}
         {{ content.field_agency_initiative_or_group }}
         {{ content.field_type_of_entity }}

--- a/html/themes/custom/iasc_common_design/templates/node/node--service--full.html.twig
+++ b/html/themes/custom/iasc_common_design/templates/node/node--service--full.html.twig
@@ -7,7 +7,7 @@
         {{ content|without('field_global_focal_point', 'field_updated', 'field_agency_initiative_or_group', 'field_type_of_entity') }}
       </div>
 
-      <aside class="cd-layout__sidebar cd-layout__sidebar--first cd-layout__sidebar--wide" role="complementary">
+      <aside class="cd-layout__sidebar cd-layout__sidebar--second cd-layout__sidebar--wide" role="complementary">
         {{ content.field_updated }}
         {{ content.field_agency_initiative_or_group }}
         {{ content.field_type_of_entity }}


### PR DESCRIPTION
# OPS-9660

- Sidebars are on the right (for LTR)
- They're skinny again, instead of wide
- They have more ARIA labels according to CD convention
- Config change: Deputies Group sidebar shows Title before the Contact List.