### PR TITLE
fix: Patch Select2 for jQuery 4 / Drupal 11 compat.

### DIFF
--- a/PATCHES/3509122-jquery4-compatibility-1.patch
+++ b/PATCHES/3509122-jquery4-compatibility-1.patch
@@ -1,0 +1,25 @@
+diff --git a/js/select2.js b/js/select2.js
+index fd2ac40..e81655a 100644
+--- a/js/select2.js
++++ b/js/select2.js
+@@ -2,6 +2,20 @@
+  * @file
+  * Select2 integration.
+  */
++
++// Support for jQuery 4 #6298
++// @see https://github.com/select2/select2/issues/6298
++if (!jQuery.isArray) {
++  jQuery.isArray = Array.isArray || function (value) {
++    return Object.prototype.toString.call(value) === '[object Array]';
++  };
++}
++if (!jQuery.trim) {
++  jQuery.trim = function (text) {
++    return text == null ? "" : text.trim();
++  };
++}
++
+ (function ($, drupalSettings, Sortable, once) {
+   'use strict';
+ 

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -36,6 +36,9 @@
     "drupal/search_api_attachments": {
       "#3084967-41: Don't store full extracted file content data in the database": "https://www.drupal.org/files/issues/2021-08-10/search_api_attachments_files_cache-3084967-41.patch"
     },
+    "drupal/select2": {
+      "jQuery 4 compatibility": "PATCHES/3509122-jquery4-compatibility-1.patch"
+    },
     "drupal/social_auth": {
       "Type Error - #3496656": "PATCHES/social_auth-type-error-3496656.patch"
     },


### PR DESCRIPTION
Hot-fixed on production for your convenience.

Refs: IASC-808